### PR TITLE
Listen on all interfaces when running under Whonix

### DIFF
--- a/hosting/certificate.go
+++ b/hosting/certificate.go
@@ -41,7 +41,7 @@ func newCertificateServer(dir string) (*webserver, error) {
 	}
 
 	port := config.GetRandomPort()
-	address := net.JoinHostPort(defaultHost, strconv.Itoa(port))
+	address := net.JoinHostPort(defaultHost(), strconv.Itoa(port))
 
 	s := &webserver{
 		port:    port,

--- a/hosting/servers.go
+++ b/hosting/servers.go
@@ -150,7 +150,7 @@ type serverModifier func(*grumbleServer.Server)
 
 func setDefaultOptions(serv *grumbleServer.Server) {
 	serv.Set("NoWebServer", "true")
-	serv.Set("Address", "127.0.0.1")
+	serv.Set("Address", defaultHost())
 }
 
 func setWelcomeText(t string) serverModifier {


### PR DESCRIPTION
Fixes https://github.com/digitalautonomy/wahay/issues/12 .  With this PR (and some onion-grater and firewall config changes that are out of the scope of this PR) I was able to host a Wahay meeting on Whonix.