### PR TITLE
Fix libtorsocks detection on ppc64le

### DIFF
--- a/tor/binary.go
+++ b/tor/binary.go
@@ -15,13 +15,6 @@ import (
 
 const libTorsocks = "libtorsocks.so"
 
-var libDirs = []string{
-	"/lib",
-	"/lib64",
-	"/lib/x86_64-linux-gnu",
-	"/lib64/x86_64-linux-gnu",
-}
-
 var libPrefixes = []string{
 	"",
 	"/usr",

--- a/tor/libdirs_default.go
+++ b/tor/libdirs_default.go
@@ -1,0 +1,10 @@
+// +build !ppc64le
+
+package tor
+
+var libDirs = []string{
+	"/lib",
+	"/lib64",
+	"/lib/x86_64-linux-gnu",
+	"/lib64/x86_64-linux-gnu",
+}

--- a/tor/libdirs_ppc64le.go
+++ b/tor/libdirs_ppc64le.go
@@ -1,0 +1,8 @@
+package tor
+
+var libDirs = []string{
+	"/lib",
+	"/lib64",
+	"/lib/powerpc64le-linux-gnu",
+	"/lib64/powerpc64le-linux-gnu",
+}


### PR DESCRIPTION
On ppc64le systems (e.g. the Talos II Secure Workstation), Wahay fails to find libtorsocks because it's looking in x86_64-specific directories.  With this PR applied, Wahay found libtorsocks on ppc64le.  (Probably other non-x86_64 arches will need similar patches applied, but I haven't tested on any other arches, so I'm not certain which directories would be correct for those.)