### PR TITLE
Add error logging for missing libtorsocks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,6 +122,7 @@ func (c *client) Launch(url string, onClose func()) (tor.Service, error) {
 func (c *client) execute(args []string, onClose func()) (tor.Service, error) {
 	s, err := c.tor.NewService(c.pathToBinary(), args, c.torCommandModifier())
 	if err != nil {
+		log.Errorf("Mumble client execute(): %s", err.Error())
 		return nil, errors.New("error: the service can't be started")
 	}
 


### PR DESCRIPTION
Wahay currently logs a very confusing/unhelpful "the service can't be started" error when it can't find libtorsocks; this made it difficult to diagnose https://github.com/digitalautonomy/wahay/pull/15 .  This PR adds better logging for this error case.