### PR TITLE
fix transparent fonts in configure meeting window

### DIFF
--- a/gui/definitions/ConfigureMeetingWindow.xml
+++ b/gui/definitions/ConfigureMeetingWindow.xml
@@ -313,6 +313,9 @@
                     <property name="yalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="on_chkAutoJoin_toggled" swapped="no"/>
+                    <style>
+                      <class name="GtkCheckButton"/>
+                    </style>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -336,6 +339,9 @@
                 <property name="tooltip_text" translatable="yes">As a super user you will be able to do things that others do not, such as silencing another user or expelling him/her from the meeting, etc.</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_chkAutoJoinSuperUser_toggled" swapped="no"/>
+                <style>
+                  <class name="GtkCheckButton"/>
+                </style>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/sass/ui/configure-meeting-window.scss
+++ b/sass/ui/configure-meeting-window.scss
@@ -1,0 +1,3 @@
+.GtkCheckButton {
+  color: black;
+}


### PR DESCRIPTION
Apply a black color rule to GtkCheckButton to make the fonts visible

* fixes #40

I have checked that it does not alter anything in case it already appears correctly, like in the Fedora VM mentioned in the linked issue

![checkbox_ok](https://github.com/user-attachments/assets/2a29e39c-6b99-4de5-b8f6-d9a0b7902d1f)
