### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/tor/search_binary_posix.go
+++ b/tor/search_binary_posix.go
@@ -39,7 +39,7 @@ func findTorBinaryInSystem() (b *binary, fatalErr error) {
 	b, errTorBinary := isThereConfiguredTorBinary(path)
 
 	if errTorBinary != nil {
-		return nil, err
+		return nil, errTorBinary
 	}
 
 	return b, nil


### PR DESCRIPTION
Since we have already checked err before and returned when err != nil, err must be nil here. In fact, it should return  `errTorBinary `.